### PR TITLE
REX64: convert to function-type macro

### DIFF
--- a/jit/codegen_x86.cpp
+++ b/jit/codegen_x86.cpp
@@ -4734,15 +4734,15 @@ LOWFUNC(NONE,NONE,2,raw_ftan_rr,(FW d, FR s))
 LENDFUNC(NONE,NONE,2,raw_ftan_rr,(FW d, FR s))
 
 #ifdef CPU_x86_64
-#define REX64 emit_byte(0x48);
+#define REX64() emit_byte(0x48)
 #else
-#define REX64
+#define REX64()
 #endif
 
 LOWFUNC(NONE,NONE,1,raw_fcuts_r,(FRW r))
 {
 	make_tos(r);     /* TOS = r */
-	REX64
+	REX64();
 	emit_byte(0x83);
 	emit_byte(0xc4);
 	emit_byte(0xfc); /* add -4 to esp */
@@ -4753,7 +4753,7 @@ LOWFUNC(NONE,NONE,1,raw_fcuts_r,(FRW r))
 	emit_byte(0x04);
 	emit_byte(0x24); /* fld load r as SINGLE from [esp] */
 	emit_byte(0x9b); /* let the CPU wait on FPU exceptions */
-	REX64
+	REX64();
 	emit_byte(0x83);
 	emit_byte(0xc4);
 	emit_byte(0x04); /* add +4 to esp */
@@ -4763,7 +4763,7 @@ LENDFUNC(NONE,NONE,1,raw_fcuts_r,(FRW r))
 LOWFUNC(NONE,NONE,1,raw_fcut_r,(FRW r))
 {
 	make_tos(r);     /* TOS = r */
-	REX64
+	REX64();
 	emit_byte(0x83);
 	emit_byte(0xc4);
 	emit_byte(0xf8); /* add -8 to esp */
@@ -4774,7 +4774,7 @@ LOWFUNC(NONE,NONE,1,raw_fcut_r,(FRW r))
 	emit_byte(0x04);
 	emit_byte(0x24); /* fld load r as DOUBLE from [esp] */
 	emit_byte(0x9b); /* let the CPU wait on FPU exceptions */
-	REX64
+	REX64();
 	emit_byte(0x83);
 	emit_byte(0xc4);
 	emit_byte(0x08); /* add +8 to esp */
@@ -5026,7 +5026,7 @@ LOWFUNC(NONE,NONE,2,raw_fsinh_rr,(FW d, FR s))
 	if (tr>=0) {
 		emit_byte(0xd9);
 		emit_byte(0xca); /* fxch swap with temp-reg */
-		REX64
+		REX64();
 		emit_byte(0x83);
 		emit_byte(0xc4);
 		emit_byte(0xf4); /* add -12 to esp */
@@ -5074,7 +5074,7 @@ LOWFUNC(NONE,NONE,2,raw_fsinh_rr,(FW d, FR s))
 		emit_byte(0xca); /* fxch swap temp-reg with e^-x in tr */
 		emit_byte(0xde);
 		emit_byte(0xe9); /* fsubp (e^x)-(e^-x) */
-		REX64
+		REX64();
 		emit_byte(0x83);
 		emit_byte(0xc4);
 		emit_byte(0x0c); /* delayed add +12 to esp */
@@ -5119,7 +5119,7 @@ LOWFUNC(NONE,NONE,2,raw_fcosh_rr,(FW d, FR s))
 	if (tr>=0) {
 		emit_byte(0xd9);
 		emit_byte(0xca); /* fxch swap with temp-reg */
-		REX64
+		REX64();
 		emit_byte(0x83);
 		emit_byte(0xc4);
 		emit_byte(0xf4); /* add -12 to esp */
@@ -5165,7 +5165,7 @@ LOWFUNC(NONE,NONE,2,raw_fcosh_rr,(FW d, FR s))
 		emit_byte(0x24); /* fld load temp-reg from [esp] */
 		emit_byte(0xd9);
 		emit_byte(0xca); /* fxch swap temp-reg with e^-x in tr */
-		REX64
+		REX64();
 		emit_byte(0x83);
 		emit_byte(0xc4);
 		emit_byte(0x0c); /* delayed add +12 to esp */
@@ -5208,7 +5208,7 @@ LOWFUNC(NONE,NONE,2,raw_ftanh_rr,(FW d, FR s))
 	if (tr>=0) {
 		emit_byte(0xd9);
 		emit_byte(0xca); /* fxch swap with temp-reg */
-		REX64
+		REX64();
 		emit_byte(0x83);
 		emit_byte(0xc4);
 		emit_byte(0xf4); /* add -12 to esp */
@@ -5262,7 +5262,7 @@ LOWFUNC(NONE,NONE,2,raw_ftanh_rr,(FW d, FR s))
 		emit_byte(0xca); /* fxch swap temp-reg with e^-x in tr */
 		emit_byte(0xde);
 		emit_byte(0xf9); /* fdivp ((e^x)-(e^-x))/((e^x)+(e^-x)) */
-		REX64
+		REX64();
 		emit_byte(0x83);
 		emit_byte(0xc4);
 		emit_byte(0x0c); /* delayed add +12 to esp */


### PR DESCRIPTION
this allows to parse the file with custom tools that expect a semicolon at the end of a statement.
additionally it makes the code look like C/C++ and not like BASIC.
